### PR TITLE
Make Gitpod automatically setup & run the app in a preview

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,8 @@
 image:
   file: .gitpod.dockerfile
+ports:
+  - port: 6080
+    onOpen: open-preview
+tasks:
+  - init: pip3 install pyglet pymunk vispy keras tensorflow pyqt5
+    command: cd chap02/ && python3 game_of_life.py


### PR DESCRIPTION
Hi @hidehiro98, thank you for filing https://github.com/gitpod-io/gitpod/issues/815!

While trying to reproduce your issue, I noticed a few opportunities to better configure and automate this setup.

It should now automatically:
- install dependencies
- run chapter 02
- open the graphical window in a Virtual Desktop preview panel

<img width="1552" alt="Screenshot 2019-09-30 at 12 40 30" src="https://user-images.githubusercontent.com/599268/65872334-9ebcc080-e380-11e9-8626-da91543912dd.png">

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/hidehiro98/alife_book_src/pull/1)